### PR TITLE
Train Llama 3.1 with compressor-only updates

### DIFF
--- a/src/language_modeling/train.py
+++ b/src/language_modeling/train.py
@@ -33,6 +33,7 @@ from transformers.models.mixtral.modeling_mixtral import MixtralSparseMoeBlock
 import deepspeed
 from tokenizers import AddedToken
 import wandb
+from huggingface_hub import HfApi
 
 ## own
 from src.model import (
@@ -40,6 +41,8 @@ from src.model import (
     XMistralConfig,
     XMixtralForCausalLM,
     XMixtralConfig,
+    XLlamaForCausalLM,
+    XLlamaConfig,
     SFR,
 )
 
@@ -90,7 +93,8 @@ def parse_args():
     )
     parser.add_argument(
         "--chat_format",
-        choices=['mistral','tulu','mixtral','qwen','yi','gemma']
+        choices=['mistral','tulu','mixtral','qwen','yi','gemma','llama'],
+        default='llama'
     )
     parser.add_argument(
         "--max_train_samples",
@@ -105,9 +109,19 @@ def parse_args():
         type=str,
     )
     parser.add_argument(
+        "--model_name",
+        type=str,
+        help="Alias for --model_name_or_path",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        help="Alias for --num_train_epochs",
+    )
+    parser.add_argument(
         "--config",
         type=str,
-        required=True,
+        default="config/language_modeling/pretrain.yaml",
         help="config file to launch the training"
     )
     parser.add_argument(
@@ -142,6 +156,9 @@ def parse_args():
         "--dev_file", type=str, default=None, help="A csv or a json file containing the dev data."
     )
     parser.add_argument(
+        "--hf_repo_id", type=str, default=None, help="HuggingFace repo id for uploading the best model."
+    )
+    parser.add_argument(
         "--model_name_or_path",
         type=str,
         help="Path to pretrained model or model identifier from huggingface.co/models.",
@@ -150,6 +167,7 @@ def parse_args():
     parser.add_argument(
         "--retriever_name_or_path",
         type=str,
+        default="Salesforce/SFR-Embedding-Mistral",
         help="Path to pretrained model or model identifier from huggingface.co/models.",
         required=False,
     )
@@ -239,6 +257,11 @@ def parse_args():
         assert hasattr(args,k), f"{k} not in parsed arguments"
         if getattr(args,k) is None:
             setattr(args,k,v)
+
+    if args.model_name is not None:
+        args.model_name_or_path = args.model_name
+    if args.epochs is not None:
+        args.num_train_epochs = args.epochs
 
     args.train_file = os.path.join(args.workdir,args.train_file)
     if args.dev_file is not None:args.dev_file = os.path.join(args.workdir,args.dev_file)
@@ -337,8 +360,9 @@ def collator(
 
 
 @torch.no_grad()
-def validate_during_pretrain(model,dataloader,accelerator,vocab_size,retriever):
+def validate_during_pretrain(model, dataloader, accelerator, vocab_size, retriever):
     model.eval()
+    retriever.eval()
     total_loss = []
     for batch in dataloader:
         retrieval_embeds = get_retrieval_embeds(
@@ -358,6 +382,7 @@ def validate_during_pretrain(model,dataloader,accelerator,vocab_size,retriever):
         )
         total_loss.append(nll_loss.item())
     model.train()
+    retriever.train()
     if accelerator.use_distributed and accelerator.num_processes>1:
         all_ranks_objects = [None for _ in range(accelerator.num_processes)]
         dist.all_gather_object(all_ranks_objects,total_loss)
@@ -379,7 +404,7 @@ def main():
             retriever_tokenizer = AutoTokenizer.from_pretrained(args.retriever_name_or_path)
         retrieval_embed_length = retriever.get_embed_length()
         retriever_hidden_size = retriever.get_embed_dim()
-        retriever.eval()
+        retriever.train()
 
     accelerator = Accelerator(gradient_accumulation_steps=args.gradient_accumulation_steps, log_with="wandb")
     accelerator.init_trackers(
@@ -404,6 +429,7 @@ def main():
 
     if retriever is not None:
         retriever = retriever.to(accelerator.device)
+        retriever.train()
 
     # Make one log on every process with the configuration for debugging.
     logging.basicConfig(
@@ -454,9 +480,12 @@ def main():
 
     if args.chat_format == 'mixtral':
         MODEL_CLASS,CONFIG_CLASS = XMixtralForCausalLM,XMixtralConfig
-        tokenizer.padding_side = 'left'    
+        tokenizer.padding_side = 'left'
     if args.chat_format == 'mistral':
         MODEL_CLASS,CONFIG_CLASS = XMistralForCausalLM,XMistralConfig
+        tokenizer.padding_side = 'left'
+    if args.chat_format == 'llama':
+        MODEL_CLASS,CONFIG_CLASS = XLlamaForCausalLM, XLlamaConfig
         tokenizer.padding_side = 'left'
     config = CONFIG_CLASS.from_pretrained(args.model_name_or_path,retriever_hidden_size=retriever_hidden_size)
     model = MODEL_CLASS.from_pretrained(
@@ -482,6 +511,7 @@ def main():
     if num_added_tokens > 0:
         model.resize_token_embeddings(len(tokenizer))
     vocab_size = len(tokenizer)
+    model.requires_grad_(False)
 
     # Preprocessing the datasets.
     if args.task_type == 'finetune':
@@ -548,26 +578,9 @@ def main():
             collate_fn=collate_fn,
             batch_size=args.per_device_train_batch_size
         )
-    
-    if args.update_projector_only:
-        for n,p in model.named_parameters():
-            if 'projector' not in n:p.requires_grad = False
-            else:p.requires_grad = True
-                
-        optimizer = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad],lr=args.learning_rate)
-    else:
-        no_decay = ["bias", "layer_norm.weight"]
-        optimizer_grouped_parameters = [
-            {
-                "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
-                "weight_decay": args.weight_decay,
-            },
-            {
-                "params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)],
-                "weight_decay": 0.0,
-            },
-        ]
-        optimizer = torch.optim.AdamW(optimizer_grouped_parameters, lr=args.learning_rate)
+    if retriever is None:
+        raise ValueError("Retriever model is required for compressor training")
+    optimizer = torch.optim.AdamW(retriever.parameters(), lr=args.learning_rate)
 
     # Scheduler and math around the number of training steps.
     overrode_max_train_steps = False
@@ -597,12 +610,12 @@ def main():
 
     # Prepare everything with `accelerator`.
     if dev_dataset is not None:
-        model, optimizer, train_dataloader, lr_scheduler, dev_dataloader = accelerator.prepare(
-        model, optimizer, train_dataloader, lr_scheduler, dev_dataloader)
+        model, retriever, optimizer, train_dataloader, lr_scheduler, dev_dataloader = accelerator.prepare(
+            model, retriever, optimizer, train_dataloader, lr_scheduler, dev_dataloader)
 
     else:
-        model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
-        model, optimizer, train_dataloader, lr_scheduler)
+        model, retriever, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
+            model, retriever, optimizer, train_dataloader, lr_scheduler)
 
 
     
@@ -634,6 +647,7 @@ def main():
 
     completed_steps = 0
     starting_epoch = 0
+    best_ppl = float("inf")
 
     # logging_interval_grad_norm = 0
     logging_interval_loss = 0
@@ -676,7 +690,7 @@ def main():
                 accelerator.print('\n'+"**"*20,"show one example","**"*20)
                 save_one_sample=False
 
-            with accelerator.accumulate(model):
+            with accelerator.accumulate(retriever):
                 ## forward with retrieval embeds
                 retrieval_kwargs = {}
                 if retriever is not None:
@@ -732,7 +746,7 @@ def main():
                 logging_interval_loss += loss.detach().float()
                 accelerator.backward(loss)
                 if accelerator.sync_gradients and args.clip_grad_norm > 0:
-                    accelerator.clip_grad_norm_(model.parameters(), args.clip_grad_norm)
+                    accelerator.clip_grad_norm_(retriever.parameters(), args.clip_grad_norm)
                 optimizer.step()
                 optimizer.zero_grad()
                 lr_scheduler.step()       
@@ -768,7 +782,7 @@ def main():
                 if isinstance(checkpointing_steps, int):
                     if completed_steps % checkpointing_steps == 0:
                         output_dir = os.path.join(args.output_dir, f"step_{completed_steps}")
-                        save_with_accelerate(accelerator, model, tokenizer, output_dir,save_projector_only=args.update_projector_only)
+                        save_with_accelerate(accelerator, model, tokenizer, output_dir,save_projector_only=False)
 
                         if dev_dataloader is not None:
                             if args.task_type == 'pretrain':
@@ -778,15 +792,40 @@ def main():
                 if completed_steps >= args.max_train_steps:
                     break
 
+        if dev_dataloader is not None:
+            ppl = validate_during_pretrain(model, dev_dataloader, accelerator, vocab_size, retriever)
+            accelerator.log({"dev_ppl": ppl}, step=completed_steps)
+            if ppl < best_ppl:
+                best_ppl = ppl
+                output_dir = os.path.join(args.output_dir, "best")
+                save_with_accelerate(accelerator, model, tokenizer, output_dir, save_projector_only=False)
+                if retriever is not None and accelerator.is_main_process:
+                    comp_dir = os.path.join(output_dir, "compressor")
+                    os.makedirs(comp_dir, exist_ok=True)
+                    accelerator.unwrap_model(retriever).model.save_pretrained(comp_dir)
+                    if retriever_tokenizer is not None:
+                        retriever_tokenizer.save_pretrained(comp_dir)
+
         if args.checkpointing_steps == "epoch":
             output_dir = os.path.join(args.output_dir, f"epoch_{epoch}")
-            save_with_accelerate(accelerator, model, tokenizer, output_dir,save_projector_only=args.update_projector_only)
+            save_with_accelerate(accelerator, model, tokenizer, output_dir,save_projector_only=False)
 
     accelerator.end_training()
 
     ## save the last one
     output_dir = os.path.join(args.output_dir,"last")
     save_with_accelerate(accelerator, model, tokenizer, output_dir,save_projector_only=False)
+    if retriever is not None and accelerator.is_main_process:
+        comp_dir = os.path.join(output_dir, "compressor")
+        os.makedirs(comp_dir, exist_ok=True)
+        accelerator.unwrap_model(retriever).model.save_pretrained(comp_dir)
+        if retriever_tokenizer is not None:
+            retriever_tokenizer.save_pretrained(comp_dir)
+    if args.hf_repo_id is not None and accelerator.is_main_process:
+        api = HfApi()
+        best_dir = os.path.join(args.output_dir, "best")
+        if os.path.exists(best_dir):
+            api.upload_folder(folder_path=best_dir, repo_id=args.hf_repo_id, repo_type="model")
 
 if __name__ == "__main__":
     main()

--- a/src/language_modeling/utils.py
+++ b/src/language_modeling/utils.py
@@ -210,14 +210,14 @@ RAGInstructions = [
 
 
 
-def get_retrieval_embeds(model,input_ids,attention_mask=None):
-    with torch.no_grad():
-        embeds = model.get_doc_embedding(
-            input_ids = input_ids,
-            attention_mask = attention_mask,
-        )
-    embeds = embeds.view(-1,embeds.shape[-1])
-    return embeds 
+def get_retrieval_embeds(model, input_ids, attention_mask=None):
+    """Obtain retrieval embeddings with gradient flow."""
+    embeds = model.get_doc_embedding(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+    )
+    embeds = embeds.view(-1, embeds.shape[-1])
+    return embeds
 
 def calculate_grad_norm(model, norm_type=2):  
     total_norm = 0  

--- a/src/model/SFR/modeling_sfr.py
+++ b/src/model/SFR/modeling_sfr.py
@@ -1,70 +1,42 @@
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
-from transformers import AutoTokenizer, AutoModel
-
-from transformers import MistralForCausalLM,MistralModel
+from transformers import AutoModel
 
 
-def last_token_pool(last_hidden_states: Tensor,
-                 attention_mask: Tensor) -> Tensor:
-    left_padding = (attention_mask[:, -1].sum() == attention_mask.shape[0])
+def last_token_pool(last_hidden_states: Tensor, attention_mask: Tensor) -> Tensor:
+    left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
     if left_padding:
         return last_hidden_states[:, -1]
-    else:
-        sequence_lengths = attention_mask.sum(dim=1) - 1
-        batch_size = last_hidden_states.shape[0]
-        return last_hidden_states[torch.arange(batch_size, device=last_hidden_states.device), sequence_lengths]
+    sequence_lengths = attention_mask.sum(dim=1) - 1
+    batch_size = last_hidden_states.shape[0]
+    return last_hidden_states[torch.arange(batch_size, device=last_hidden_states.device), sequence_lengths]
 
 
-class SFR(MistralModel):
+class SFR(nn.Module):
+    def __init__(self, model: nn.Module):
+        super().__init__()
+        self.model = model
 
-    def get_embed_dim(self):
-        return self.config.hidden_size
-    
-    def get_embed_length(self):
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str, **kwargs) -> "SFR":
+        model = AutoModel.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        return cls(model)
+
+    def get_embed_dim(self) -> int:
+        return self.model.config.hidden_size
+
+    def get_embed_length(self) -> int:
         return 1
-    
-    def get_embedding(self,input_ids,attention_mask):
-        outputs = self.forward(input_ids=input_ids,attention_mask=attention_mask)
+
+    def get_embedding(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        outputs = self.model(input_ids=input_ids, attention_mask=attention_mask)
         embeddings = last_token_pool(outputs.last_hidden_state, attention_mask)
         return embeddings
-    
-    def get_doc_embedding(self,input_ids,attention_mask):
-        return self.get_embedding(input_ids,attention_mask)
-    
-    def get_query_embedding(self,input_ids,attention_mask):
-        return self.get_embedding(input_ids,attention_mask)
 
+    def get_doc_embedding(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        return self.get_embedding(input_ids, attention_mask)
 
-    # def get_detailed_instruct(task_description: str, query: str) -> str:
-    #     return f'Instruct: {task_description}\nQuery: {query}'
-
-    # # Each query must come with a one-sentence instruction that describes the task
-    # task = 'Given a web search query, retrieve relevant passages that answer the query'
-    # queries = [
-    #     get_detailed_instruct(task, 'How to bake a chocolate cake'),
-    #     get_detailed_instruct(task, 'Symptoms of the flu')
-    # ]
-    # # No need to add instruction for retrieval documents
-    # passages = [
-    #     "To bake a delicious chocolate cake, you'll need the following ingredients: all-purpose flour, sugar, cocoa powder, baking powder, baking soda, salt, eggs, milk, vegetable oil, and vanilla extract. Start by preheating your oven to 350°F (175°C). In a mixing bowl, combine the dry ingredients (flour, sugar, cocoa powder, baking powder, baking soda, and salt). In a separate bowl, whisk together the wet ingredients (eggs, milk, vegetable oil, and vanilla extract). Gradually add the wet mixture to the dry ingredients, stirring until well combined. Pour the batter into a greased cake pan and bake for 30-35 minutes. Let it cool before frosting with your favorite chocolate frosting. Enjoy your homemade chocolate cake!",
-    #     "The flu, or influenza, is an illness caused by influenza viruses. Common symptoms of the flu include a high fever, chills, cough, sore throat, runny or stuffy nose, body aches, headache, fatigue, and sometimes nausea and vomiting. These symptoms can come on suddenly and are usually more severe than the common cold. It's important to get plenty of rest, stay hydrated, and consult a healthcare professional if you suspect you have the flu. In some cases, antiviral medications can help alleviate symptoms and reduce the duration of the illness."
-    # ]
-
-    # # load model and tokenizer
-    # tokenizer = AutoTokenizer.from_pretrained('Salesforce/SFR-Embedding-Mistral')
-    # model = AutoModel.from_pretrained('Salesforce/SFR-Embedding-Mistral')
-
-    # # get the embeddings
-    # max_length = 4096
-    # input_texts = queries + passages
-    # batch_dict = tokenizer(input_texts, max_length=max_length, padding=True, truncation=True, return_tensors="pt")
-    # outputs = model(**batch_dict)
-    # embeddings = last_token_pool(outputs.last_hidden_state, batch_dict['attention_mask'])
-
-    # # normalize embeddings
-    # embeddings = F.normalize(embeddings, p=2, dim=1)
-    # scores = (embeddings[:2] @ embeddings[2:].T) * 100
-    # print(scores.tolist())
-    # # [[86.7153549194336, 36.64569091796875], [35.00493621826172, 82.0738525390625]]
+    def get_query_embedding(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        return self.get_embedding(input_ids, attention_mask)

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -1,3 +1,5 @@
 from .SFR import SFR
-from .xMistral import XMistralForCausalLM,XMistralConfig
-from .xMixtral import XMixtralConfig,XMixtralForCausalLM
+from .xMistral import XMistralForCausalLM, XMistralConfig
+from .xMixtral import XMixtralConfig, XMixtralForCausalLM
+from .xLlama import XLlamaForCausalLM, XLlamaConfig
+from .xrag_model import XRAGModel

--- a/src/model/xLlama/__init__.py
+++ b/src/model/xLlama/__init__.py
@@ -1,0 +1,1 @@
+from .modeling_xllama import XLlamaConfig, XLlamaForCausalLM

--- a/src/model/xLlama/modeling_xllama.py
+++ b/src/model/xLlama/modeling_xllama.py
@@ -1,0 +1,97 @@
+import torch
+import torch.nn as nn
+import re
+from typing import Optional, Union
+from transformers import LlamaForCausalLM, LlamaConfig
+
+
+class XLlamaConfig(LlamaConfig):
+    def __init__(self, projector_type: str = "mlp2x_gelu", retriever_hidden_size: int = 128, **kwargs):
+        super().__init__(**kwargs)
+        self.projector_type = projector_type
+        self.retriever_hidden_size = retriever_hidden_size
+
+
+class Projector(nn.Module):
+    def __init__(self, config: XLlamaConfig):
+        super().__init__()
+        projector_type = config.projector_type
+        mlp_gelu_match = re.match(r"^mlp(\d+)x_gelu$", projector_type)
+        if mlp_gelu_match:
+            mlp_depth = int(mlp_gelu_match.group(1))
+            modules = [nn.Linear(config.retriever_hidden_size, config.hidden_size)]
+            for _ in range(1, mlp_depth):
+                modules.append(nn.GELU())
+                modules.append(nn.Linear(config.hidden_size, config.hidden_size))
+            self.projector = nn.Sequential(*modules)
+        else:
+            raise ValueError(f"Unknown projector type: {projector_type}")
+
+    def forward(self, context_embedding: torch.Tensor) -> torch.Tensor:
+        return self.projector(context_embedding)
+
+
+class XLlamaForCausalLM(LlamaForCausalLM):
+    def __init__(self, config: XLlamaConfig):
+        super().__init__(config)
+        if hasattr(config, "retriever_hidden_size") and config.retriever_hidden_size > 0:
+            self.projector = Projector(config)
+            self.retriever_hidden_size = config.retriever_hidden_size
+        self.post_init()
+
+    def set_xrag_token_id(self, token_id: int) -> None:
+        self.xrag_token_id = token_id
+
+    def prepare_inputs_embeds(self, input_ids: torch.Tensor, retrieval_embeds: torch.Tensor) -> torch.Tensor:
+        inputs_embeds = self.model.embed_tokens(input_ids)
+        retrieval_embeds = retrieval_embeds.view(-1, self.retriever_hidden_size)
+        num_xrag_tokens = torch.sum(input_ids == self.xrag_token_id).item()
+        num_retrieval_embeds = retrieval_embeds.shape[0]
+        assert num_xrag_tokens == num_retrieval_embeds, (num_xrag_tokens, num_retrieval_embeds)
+        retrieval_embeds = self.projector(retrieval_embeds.to(inputs_embeds.dtype))
+        inputs_embeds[input_ids == self.xrag_token_id] = retrieval_embeds
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        retrieval_embeds: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ):
+        inputs_embeds = kwargs.pop("inputs_embeds", None)
+        at_generation_start = False
+        if inputs_embeds is not None:
+            assert not self.training
+            assert retrieval_embeds is None
+            at_generation_start = True
+        if not at_generation_start and retrieval_embeds is not None:
+            inputs_embeds = self.prepare_inputs_embeds(input_ids, retrieval_embeds)
+            input_ids = None
+            if attention_mask is not None:
+                assert inputs_embeds.shape[1] == attention_mask.shape[1]
+        return super().forward(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+
+    @torch.no_grad()
+    def generate(
+        self,
+        input_ids: Optional[torch.Tensor] = None,
+        retrieval_embeds: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ):
+        if "inputs_embeds" in kwargs:
+            raise NotImplementedError("`inputs_embeds` is not supported for generate")
+        inputs_embeds = None
+        if retrieval_embeds is not None:
+            inputs_embeds = self.prepare_inputs_embeds(input_ids, retrieval_embeds)
+            input_ids = None
+            if attention_mask is not None:
+                assert inputs_embeds.shape[1] == attention_mask.shape[1]
+            return super().generate(inputs_embeds=inputs_embeds, attention_mask=attention_mask, **kwargs)
+        return super().generate(input_ids=input_ids, attention_mask=attention_mask, **kwargs)

--- a/src/model/xrag_model.py
+++ b/src/model/xrag_model.py
@@ -1,0 +1,47 @@
+import torch
+from transformers import AutoTokenizer
+from .SFR import SFR
+from .xLlama import XLlamaForCausalLM, XLlamaConfig
+from src.language_modeling.utils import XRAG_TOKEN
+
+
+class XRAGModel(torch.nn.Module):
+    def __init__(self, model_name: str, compressor_name: str = None):
+        super().__init__()
+        compressor_name = compressor_name or f"{model_name}/compressor"
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.compressor_tokenizer = AutoTokenizer.from_pretrained(compressor_name)
+        self.compressor = SFR.from_pretrained(compressor_name)
+        base_config = XLlamaConfig.from_pretrained(model_name)
+        self.llm = XLlamaForCausalLM.from_pretrained(model_name, config=base_config)
+        # freeze base model; only the compressor will be updated during training
+        self.llm.requires_grad_(False)
+        self.xrag_token_id = self.tokenizer.convert_tokens_to_ids(XRAG_TOKEN)
+        if self.xrag_token_id == self.tokenizer.unk_token_id:
+            self.tokenizer.add_special_tokens({"additional_special_tokens": [XRAG_TOKEN]})
+            self.llm.resize_token_embeddings(len(self.tokenizer))
+            self.xrag_token_id = self.tokenizer.convert_tokens_to_ids(XRAG_TOKEN)
+        self.llm.set_xrag_token_id(self.xrag_token_id)
+
+    def forward(self, query_ids, query_mask, doc_ids, doc_mask, labels):
+        retrieval = self.compressor.get_doc_embedding(doc_ids, doc_mask)
+        outputs = self.llm(
+            input_ids=query_ids,
+            attention_mask=query_mask,
+            retrieval_embeds=retrieval,
+            labels=labels,
+        )
+        return outputs
+
+    @torch.no_grad()
+    def generate(self, query: str, document: str, **kwargs) -> str:
+        query_tokens = self.tokenizer(query + XRAG_TOKEN, return_tensors="pt")
+        doc_tokens = self.compressor_tokenizer(document, return_tensors="pt", truncation=True)
+        retrieval = self.compressor.get_doc_embedding(doc_tokens["input_ids"], doc_tokens["attention_mask"])
+        output_ids = self.llm.generate(
+            input_ids=query_tokens["input_ids"],
+            attention_mask=query_tokens["attention_mask"],
+            retrieval_embeds=retrieval,
+            **kwargs,
+        )
+        return self.tokenizer.decode(output_ids[0], skip_special_tokens=True)


### PR DESCRIPTION
## Summary
- add `--model_name` and `--epochs` aliases for simple training commands
- freeze Llama weights and optimize only the SFR compressor
- save and upload both the language model and compressor for best and final checkpoints

## Testing
- `python -m py_compile src/language_modeling/train.py src/language_modeling/utils.py src/model/xrag_model.py`
- `PYTHONPATH=. python src/language_modeling/train.py --help` (after installing deps)


------
https://chatgpt.com/codex/tasks/task_e_68aedde38e548329b2abdf6139bea823